### PR TITLE
Update License to Licence

### DIFF
--- a/.github/tool-configurations/labeller.yml
+++ b/.github/tool-configurations/labeller.yml
@@ -21,7 +21,7 @@ markdown:
               [
                 "docs/*.md",
                 "*.md",
-                "LICENSE",
+                "LICENCE",
                 ".github/pull_request_template.md",
               ]
 python:


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the documentation label configuration in `.github/other-configurations/labeller.yml` to correct the spelling of the license file reference.

* Changed the documentation label pattern from `LICENSE` to `LICENCE` in the `markdown:` section of `.github/other-configurations/labeller.yml` to match the correct file name.