### PR TITLE
Update Prek Freeze Command

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -97,7 +97,7 @@ prek-update:
 
 # Prek update hooks
 prek-update-hooks:
-    prek autoupdate
+    prek update --freeze
 
 prek-update-additional-dependencies:
     uv run --script https://raw.githubusercontent.com/JackPlowman/update-prek-additional-dependencies/refs/heads/main/update_prek_additional_dependencies.py
@@ -110,4 +110,3 @@ prek-update-additional-dependencies:
 update:
     just pinact-update
     just prek-update
-    just prek-update-additional-dependencies


### PR DESCRIPTION
# Pull Request

## Description

This pull request makes a small adjustment to the `Justfile` to improve how Prek dependencies are updated. The main change is switching the `prek-update-hooks` command to use `prek update --freeze` for more controlled updates, and removing the automatic running of additional dependency updates from the main `update` recipe.

- Prek update process:
  * Changed the `prek-update-hooks` command from `prek autoupdate` to `prek update --freeze` for more predictable dependency management.

- Update workflow:
  * Removed `just prek-update-additional-dependencies` from the main `update` recipe, so additional dependencies are no longer updated automatically during a standard update.